### PR TITLE
Accept HEAD request

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -44,6 +44,10 @@ module Idobata::Hook
       'OK'
     end
 
+    route :head, '/:identifier' do
+      Idobata::Hook.find(params[:identifier])
+    end
+
     private
 
     def post_to_idobata(payload)


### PR DESCRIPTION
It responses with 200 OK if hook exists, otherwise 500 Internal Server Error.

I would like add this HEAD route because some service that I am developing hook for sends HEAD request to verify webhook URI when registering it.

Thank you.
