### PR TITLE
Add spec to check syntax of style.css.sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.sass-cache
 .yardoc
 InstalledFiles
 _yardoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       hashie
       html-pipeline
       mime-types
+      sass
       tilt
 
 GEM
@@ -97,6 +98,7 @@ GEM
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
     rugged (0.21.0)
+    sass (3.3.10)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)

--- a/idobata-hooks.gemspec
+++ b/idobata-hooks.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hashie'
   spec.add_dependency 'html-pipeline'
   spec.add_dependency 'mime-types'
+  spec.add_dependency 'sass'
   spec.add_dependency 'tilt'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/spec/idoabta_hook_spec.rb
+++ b/spec/idoabta_hook_spec.rb
@@ -31,4 +31,18 @@ describe Idobata::Hook do
       end
     end
   end
+
+  describe 'style.css.sass' do
+    Idobata::Hook.all.each do |hook|
+      describe hook do
+        subject { hook }
+
+        let(:path) { hook.hook_root.join('style.css.sass').to_s }
+
+        it 'should be compiled successfully' do
+          Tilt.new(path).render if File.exist?(path)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is because I committed invalid `style.css.sass` in #11. :crying_cat_face: I thought that it would be nice to add spec to check syntax of `style.css.sass` since there is a spec to check `instructions.js.hbs.hamlbars`.
