### PR TITLE
process FINALIZED phase in Jenkins notification

### DIFF
--- a/lib/hooks/jenkins_notification/hook.rb
+++ b/lib/hooks/jenkins_notification/hook.rb
@@ -8,7 +8,7 @@ module Idobata::Hook
     helper Helper
 
     before_render do
-      skip_processing! unless payload.build.phase == 'FINISHED'
+      skip_processing! unless %w( FINISHED FINALIZED ).include?(payload.build.phase)
     end
   end
 end

--- a/spec/fixtures/payload/jenkins_notification/finalized.json
+++ b/spec/fixtures/payload/jenkins_notification/finalized.json
@@ -1,0 +1,11 @@
+{
+  "name": "support",
+  "url": "job/support/",
+  "build": {
+    "full_url": "http://localhost:8080/job/support/148/",
+    "number": 148,
+    "phase": "FINALIZED",
+    "status": "SUCCESS",
+    "url": "job/support/148/"
+  }
+}

--- a/spec/jenkins_notification_spec.rb
+++ b/spec/jenkins_notification_spec.rb
@@ -4,9 +4,7 @@ describe Idobata::Hook::JenkinsNotification, type: :hook do
   describe '#process_payload' do
     subject { hook.process_payload }
 
-    context 'phase is "FINISHED"' do
-      let(:payload) { fixture_payload('jenkins_notification/finished.json') }
-
+    shared_examples 'processing payload with URL to job' do
       before do
         post payload, 'Content-Type' => 'application/json'
       end
@@ -20,6 +18,18 @@ describe Idobata::Hook::JenkinsNotification, type: :hook do
         </p>
       HTML
       its([:format]) { should eq(:html) }
+    end
+
+    context 'phase is "FINALIZED"' do
+      it_should_behave_like 'processing payload with URL to job' do
+        let(:payload) { fixture_payload('jenkins_notification/finalized.json') }
+      end
+    end
+
+    context 'phase is "FINISHED"' do
+      it_should_behave_like 'processing payload with URL to job' do
+        let(:payload) { fixture_payload('jenkins_notification/finished.json') }
+      end
     end
 
     context 'Old jenkins (build.full_url is missing)' do


### PR DESCRIPTION
Since version 1.6 of Jenkins Notification plugin, the last phase has renamed to "FINALIZED" from "FINISHED". (See example of notification message on [this page](https://wiki.jenkins-ci.org/display/JENKINS/Notification+Plugin).)
