### PR TITLE
Skip `project' event for now

### DIFF
--- a/lib/hooks/qiita_team/hook.rb
+++ b/lib/hooks/qiita_team/hook.rb
@@ -1,5 +1,7 @@
 module Idobata::Hook
   class QiitaTeam < Base
+    UNSUPPORTED_EVENTS = Set.new(%w(project))
+
     screen_name   'Qiita:Team'
     identifier    :qiita_team
     icon_url      gravatar('a42654d10bb5293ca1bfe6ab3ea049e5')
@@ -8,7 +10,7 @@ module Idobata::Hook
     helper Helper
 
     before_render do
-      skip_processing! if destroyed?
+      skip_processing! if destroyed? || UNSUPPORTED_EVENTS.include?(event_model_type)
     end
 
     private

--- a/spec/fixtures/payload/qiita_team/project_created.json
+++ b/spec/fixtures/payload/qiita_team/project_created.json
@@ -1,0 +1,28 @@
+{
+  "model": "project",
+  "action": "created",
+  "project": {
+    "id": 12,
+    "name": "Sample Project",
+    "created_at": "2014-07-03 17:07:55 +0900",
+    "created_at_in_words": "1分未満",
+    "created_at_as_seconds": 1404374875,
+    "updated_at": "2014-07-03 17:07:55 +0900",
+    "updated_at_in_words": "1分未満",
+    "tags": [{
+      "name": "python",
+      "url_name": "python",
+      "icon_url": "/icons/medium/missing.png"
+    }],
+    "raw_body": "this is a test project\n",
+    "body": "<p>this is a test project</p>\n",
+    "comment_count": 0,
+    "url": "http://increments.qiita.dev/projects/12",
+    "archived": false
+  },
+  "user": {
+    "id": 9,
+    "url_name": "qiitan",
+    "profile_image_url": "user_image.jpg"
+  }
+}

--- a/spec/qiita_team_spec.rb
+++ b/spec/qiita_team_spec.rb
@@ -127,8 +127,17 @@ describe Idobata::Hook::QiitaTeam, type: :hook do
       its([:format]) { should eq(:html) }
     end
 
+    describe 'project created event' do
+      subject { -> { hook.process_payload } }
+
+      let(:fixture) { 'project_created.json' }
+      let(:qiita_event_model_type) { 'project' }
+
+      it { expect(subject).to raise_error(Idobata::Hook::SkipProcessing) }
+    end
+
     describe 'destroy actions' do
-      subject { ->{ hook.process_payload } }
+      subject { -> { hook.process_payload } }
 
       describe 'item destroyed event' do
         let(:fixture) { 'item_destroyed.json' }


### PR DESCRIPTION
Because there are no templates for `project' events.
