### PR TITLE
Specify emoji size for bitbucket-html

### DIFF
--- a/lib/hooks/bitbucket/style.css.sass
+++ b/lib/hooks/bitbucket/style.css.sass
@@ -1,0 +1,4 @@
+.bitbucket-html
+  img.emoji
+    width: 20px
+    height: 20px

--- a/lib/hooks/bitbucket/templates/_pull_request_comment.html.haml
+++ b/lib/hooks/bitbucket/templates/_pull_request_comment.html.haml
@@ -9,4 +9,4 @@
 #{action} on pull request
 %a{href: comment_url}= pull_request_name_from_api_url(body.links.self.href)
 
-!= body.content.html
+.bitbucket-html!= body.content.html

--- a/spec/bitbucket_spec.rb
+++ b/spec/bitbucket_spec.rb
@@ -123,7 +123,7 @@ describe Idobata::Hook::Bitbucket, type: :hook do
           <a href='https://bitbucket.org/tricknotes'>Ryunosuke SATO</a>
           commented on pull request
           <a href='https://bitbucket.org/ursm/hello/pull-request/20/_/diff#comment-1236863'>ursm/hello#20</a>
-          <p>+1 for me</p>
+          <div class='bitbucket-html'><p>+1 for me</p></div>
         HTML
       end
 
@@ -137,7 +137,7 @@ describe Idobata::Hook::Bitbucket, type: :hook do
           <a href='https://bitbucket.org/tricknotes'>Ryunosuke SATO</a>
           updated comment on pull request
           <a href='https://bitbucket.org/tricknotes/notification-test/pull-request/11/_/diff#comment-1316114'>tricknotes/notification-test#11</a>
-          <p>updated!</p>
+          <div class='bitbucket-html'><p>updated!</p></div>
         HTML
       end
 


### PR DESCRIPTION
img.emoji doesn't have both height and width attributes.
But oh well, we have to show them in good size.

![selection_014](https://cloud.githubusercontent.com/assets/43346/5312469/a72ea67e-7c9d-11e4-8a09-9ef0e07a9aef.png)
