### PR TITLE
Use meaningful URL for gitlab icon

### DIFF
--- a/lib/hooks/gitlab/hook.rb
+++ b/lib/hooks/gitlab/hook.rb
@@ -2,7 +2,7 @@ module Idobata::Hook
   class Gitlab < Base
     screen_name   'Gitlab'
     identifier    :gitlab
-    icon_url      'https://avatars2.githubusercontent.com/u/1086321?s=84'
+    icon_url      'https://github.com/gitlabhq.png'
     template_name { "#{event_type}.html.haml" }
 
     helper Helper


### PR DESCRIPTION
This URL will be redirected to `https://*.githubusercontent.com/u/1086321?v=3`.
