### PR TITLE
Update Ruby version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.1.2
+rvm: 2.1.5
 cache: [bundler, apt]
 
 before_install:


### PR DESCRIPTION
Currently, It seems that idobata-hooks should be tested with Ruby 2.1.5.
see: https://github.com/idobata/idobata-hooks/commit/04d782f5b760fe1a8270829fdabf9b646c80aa20
