### PR TITLE
Improve Airbrake notification

### DIFF
--- a/lib/hooks/airbrake/templates/default.html.haml
+++ b/lib/hooks/airbrake/templates/default.html.haml
@@ -5,5 +5,6 @@
 
 %p
   %b= payload.error.error_message
-  from
-  %a{href: payload.error.last_notice.request_url}= payload.error.last_notice.request_url
+  - if payload.error.last_notice.request_url
+    from
+    %a{href: payload.error.last_notice.request_url}= payload.error.last_notice.request_url


### PR DESCRIPTION
Show `request_url` if `request_url` exists. `request_url` couldn't exist in case of plain Ruby, Rake and so on.
