### PR TITLE
Add Crashlytics WebHook

### DIFF
--- a/lib/hooks/crashlytics/helper.rb
+++ b/lib/hooks/crashlytics/helper.rb
@@ -1,0 +1,19 @@
+module Idobata::Hook
+  class Crashlytics
+    module Helper
+      def label_class_from_impact_level(impact_level)
+        if impact_level >= 5
+          'label-important'
+        elsif impact_level == 4
+          'label-warning'
+        elsif impact_level == 3
+          'label-success'
+        elsif impact_level == 2
+          'label-info'
+        else
+          'label-inverse'
+        end
+      end
+    end
+  end
+end

--- a/lib/hooks/crashlytics/hook.rb
+++ b/lib/hooks/crashlytics/hook.rb
@@ -1,0 +1,21 @@
+module Idobata::Hook
+  class Crashlytics < Base
+    screen_name         'Crashlytics'
+    identifier          :crashlytics
+    icon_url            'https://crashlytics.com/apple-touch-icon-crashlytics.png'
+    forced_content_type :json
+    template_name       { custom_template_name }
+
+    helper Helper
+
+    private
+
+    def custom_template_name
+      if payload['event'] == 'verification'
+        'verification.html.haml'
+      elsif payload['event'] == 'issue_impact_change'
+        'default.html.haml'
+      end
+    end
+  end
+end

--- a/lib/hooks/crashlytics/instructions.js.hbs.hamlbars
+++ b/lib/hooks/crashlytics/instructions.js.hbs.hamlbars
@@ -1,0 +1,4 @@
+%dl
+  %dt Usage
+  %dd
+    Setup a Crashlytics WebHook at https://fabric.io/settings/apps/[your_app_id]/service_hooks/webhook

--- a/lib/hooks/crashlytics/templates/default.html.haml
+++ b/lib/hooks/crashlytics/templates/default.html.haml
@@ -1,0 +1,7 @@
+%p
+  %span.label{class: label_class_from_impact_level(payload.payload.impact_level)}
+    #{payload.payload.crashes_count} crashes, #{payload.payload.impacted_devices_count} devices
+  #{payload.payload.app.bundle_identifier} #{payload.payload.synthesized_build}
+%h4= payload.payload.title
+%h5= payload.payload.subtitle
+%p= payload.payload.url

--- a/lib/hooks/crashlytics/templates/verification.html.haml
+++ b/lib/hooks/crashlytics/templates/verification.html.haml
@@ -1,0 +1,1 @@
+%h4 Crashlytics WebHook has been registered!

--- a/spec/crashlytics_spec.rb
+++ b/spec/crashlytics_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Idobata::Hook::Crashlytics, type: :hook do
+  before do
+    post payload, 'Content-Type' => 'application/json'
+  end
+
+  describe '#process_payload' do
+    subject { hook.process_payload }
+
+    context 'verification' do
+      let(:payload) { fixture_payload("crashlytics/verification.json") }
+
+      its([:source]) { should eq(<<-HTML.strip_heredoc) }
+        <h4>Crashlytics WebHook has been registered!</h4>
+      HTML
+    end
+
+    context 'issue_impact_change' do
+      let(:payload) { fixture_payload("crashlytics/issue_impact_change.json") }
+
+      its([:source]) { should eq(<<-HTML.strip_heredoc) }
+        <p>
+          <span class='label label-info'>
+            54 crashes, 16 devices
+          </span>
+          com.example.myapp 1.0.3 (4)
+        </p>
+        <h4>Issue Title</h4>
+        <h5>com.example.myapp.MyAppUtil.methodName</h5>
+        <p>http://crashlytics.com/full/url/to/issue</p>
+      HTML
+    end
+  end
+end

--- a/spec/fixtures/payload/crashlytics/issue_impact_change.json
+++ b/spec/fixtures/payload/crashlytics/issue_impact_change.json
@@ -1,0 +1,16 @@
+{
+  "event": "issue_impact_change",
+  "payload_type": "issue",
+  "payload": {
+    "display_id": 123 ,
+    "title": "Issue Title" ,
+    "subtitle": "com.example.myapp.MyAppUtil.methodName",
+    "method": "methodName",
+    "synthesized_build": "1.0.3 (4)",
+    "impact_level": 2,
+    "crashes_count": 54,
+    "impacted_devices_count": 16,
+    "url": "http://crashlytics.com/full/url/to/issue",
+    "app": {"name": "MyApp", "bundle_identifier": "com.example.myapp", "platform":"android"}
+  }
+}

--- a/spec/fixtures/payload/crashlytics/verification.json
+++ b/spec/fixtures/payload/crashlytics/verification.json
@@ -1,0 +1,4 @@
+{
+  "event": "verification",
+  "payload_type": "none"
+}


### PR DESCRIPTION
Add support for [Crashlyticsh WebHook](ttps://dev.twitter.com/crashlytics/crash-reporting/web-hooks)

![_73__idobata](https://cloud.githubusercontent.com/assets/28143/6310341/3879b366-b999-11e4-8927-93f1192bac83.png)

