### PR TITLE
Support GitLab "project_create" event

### DIFF
--- a/lib/hooks/gitlab/hook.rb
+++ b/lib/hooks/gitlab/hook.rb
@@ -12,6 +12,7 @@ module Idobata::Hook
       return 'push'              if payload.has_key?('commits')
       return 'tag'               if payload.has_key?('ref')
       return payload.object_kind if payload.has_key?('object_kind')
+      return payload.event_name  if payload.has_key?('event_name')
 
       raise "Unknown Gitlab event: #{payload.to_json}"
     end

--- a/lib/hooks/gitlab/templates/project_create.html.haml
+++ b/lib/hooks/gitlab/templates/project_create.html.haml
@@ -1,0 +1,1 @@
+The new project <b>#{payload.path_with_namespace}</b> is created.

--- a/spec/fixtures/payload/gitlab/project_create.json
+++ b/spec/fixtures/payload/gitlab/project_create.json
@@ -1,0 +1,11 @@
+{
+  "event_name": "project_create",
+  "created_at": "2015-06-26T01:22:56Z",
+  "name": "hoi",
+  "path": "hoi",
+  "path_with_namespace": "alice/hoi",
+  "project_id": 67,
+  "owner_name": "alice",
+  "owner_email": null,
+  "project_visibility": "internal"
+}

--- a/spec/gitlab_spec.rb
+++ b/spec/gitlab_spec.rb
@@ -111,5 +111,13 @@ describe Idobata::Hook::Gitlab, type: :hook do
        </p>
       HTML
     end
+
+    describe 'project create event' do
+      let(:fixture) { 'project_create.json' }
+
+      its([:source]) { should eq(<<-HTML.strip_heredoc) }
+        The new project <b>alice/hoi</b> is created.
+      HTML
+    end
   end
 end


### PR DESCRIPTION
This is preview message.
![2015-06-26 12 09 36](https://cloud.githubusercontent.com/assets/290782/8369959/53a1e396-1bfc-11e5-8834-829942fffee0.png)

It would be great if the link to project is present.
But payload from GitLab has no such data...:<