### PR TITLE
Prevent CloudFormation hook from failing

### DIFF
--- a/lib/hooks/cloudformation/helper.rb
+++ b/lib/hooks/cloudformation/helper.rb
@@ -3,7 +3,7 @@ module Idobata::Hook
     module Helper
       def message
         payload['Message'].gsub(/\n(?=')/, '').split("\n").map{ |s|
-          s.match(/\A(.+)='(.+)'\z/).to_a.drop(1)
+          s.match(/\A(.+)='(.*)'\z/).to_a.drop(1)
         }.to_h
       end
 

--- a/spec/cloudformation_spec.rb
+++ b/spec/cloudformation_spec.rb
@@ -8,7 +8,7 @@ describe Idobata::Hook::Cloudformation, type: :hook do
 
     subject { hook.process_payload }
 
-    context 'subscription_confirmation' do
+    describe 'subscription_confirmation' do
       let(:payload) { fixture_payload('cloudformation/subscription_confirmation.json') }
 
       its([:source]) { should eq <<-HTML.strip_heredoc }
@@ -22,21 +22,37 @@ describe Idobata::Hook::Cloudformation, type: :hook do
       its([:format]) { should eq :html }
     end
 
-    context 'notification' do
-      let(:payload) { fixture_payload('cloudformation/notification.json') }
+    describe 'notification' do
+      context 'resource status reason is included' do
+        let(:payload) { fixture_payload('cloudformation/notification_including_reason.json') }
 
-      its([:source]) { should eq <<-HTML.strip_heredoc }
-        <p>
-          <span class='label label-warning'>CREATE_IN_PROGRESS</span>
-          <b>stack:</b>
-          VPC
-          (AWS::EC2::VPC)
-        </p>
-        <p>
-          Resource creation Initiated
-        </p>
-      HTML
-      its([:format]) { should eq :html }
+        its([:source]) { should eq <<-HTML.strip_heredoc }
+          <p>
+            <span class='label label-warning'>CREATE_IN_PROGRESS</span>
+            <b>stack:</b>
+            VPC
+            (AWS::EC2::VPC)
+          </p>
+          <p>
+            Resource creation Initiated
+          </p>
+        HTML
+        its([:format]) { should eq :html }
+      end
+
+      context %q{resource status reason isn't included} do
+        let(:payload) { fixture_payload('cloudformation/notification.json') }
+
+        its([:source]) { should eq <<-HTML.strip_heredoc }
+          <p>
+            <span class='label label-success'>CREATE_COMPLETE</span>
+            <b>stack:</b>
+            VPC
+            (AWS::EC2::VPC)
+          </p>
+        HTML
+        its([:format]) { should eq :html }
+      end
     end
   end
 end

--- a/spec/fixtures/payload/cloudformation/notification_including_reason.json
+++ b/spec/fixtures/payload/cloudformation/notification_including_reason.json
@@ -3,7 +3,7 @@
   "MessageId": "xxxxx",
   "TopicArn": "arn:aws:sns:us-east-1:xxxxx:xxxxx",
   "Subject": "AWS CloudFormation Notification",
-  "Message": "StackId='arn:aws:cloudformation:us-east-1:xxxxx:stack/stack/xxxxx'\nTimestamp='2015-06-19T19:34:02.614Z'\nEventId='xxxxx'\nLogicalResourceId='VPC'\nNamespace='xxxxx'\nPhysicalResourceId='vpc-xxxxx'\nResourceProperties='{\"CidrBlock\":\"10.0.0.0/16\"}\n'\nResourceStatus='CREATE_COMPLETE'\nResourceStatusReason=''\nResourceType='AWS::EC2::VPC'\nStackName='stack'\n",
+  "Message": "StackId='arn:aws:cloudformation:us-east-1:xxxxx:stack/stack/xxxxx'\nTimestamp='2015-06-19T19:33:19.133Z'\nEventId='xxxxx'\nLogicalResourceId='VPC'\nNamespace='xxxxx'\nPhysicalResourceId='vpc-xxxxx'\nResourceProperties='{\"CidrBlock\":\"10.0.0.0/16\"}\n'\nResourceStatus='CREATE_IN_PROGRESS'\nResourceStatusReason='Resource creation Initiated'\nResourceType='AWS::EC2::VPC'\nStackName='stack'\n",
   "Timestamp": "2015-06-19T19:33:19.210Z",
   "SignatureVersion": "1",
   "Signature": "xxxxx",


### PR DESCRIPTION
It fail if a value (e.g. ResourceStatusReason) is empty, bacause an empty value presence can't be assumed.