### PR TITLE
esa: Display 'post.body_md' on post_create and post_update (\( ⁰⊖⁰)/) 

### DIFF
--- a/lib/hooks/esa/templates/post_create.html.haml
+++ b/lib/hooks/esa/templates/post_create.html.haml
@@ -4,3 +4,5 @@
   = link_to_post(payload.team, payload.post)
 
 %blockquote= payload.post.message
+<br />
+= md payload.post.body_md

--- a/lib/hooks/esa/templates/post_update.html.haml
+++ b/lib/hooks/esa/templates/post_update.html.haml
@@ -4,3 +4,5 @@
   = link_to_post(payload.team, payload.post, with_diff: true)
 
 %blockquote= payload.post.message
+<br />
+= md payload.post.body_md

--- a/spec/esa_spec.rb
+++ b/spec/esa_spec.rb
@@ -44,6 +44,8 @@ describe Idobata::Hook::Esa, type: :hook do
         <b>たいとる</b>
       </p>
       <blockquote>Create post.</blockquote>
+      <br />
+      <p>ほんぶん</p>
       HTML
     end
 
@@ -67,6 +69,8 @@ describe Idobata::Hook::Esa, type: :hook do
         <b>たいとる</b>
       </p>
       <blockquote>Update post.</blockquote>
+      <br />
+      <p>ほんぶん</p>
       HTML
     end
 


### PR DESCRIPTION
To get [the same way as built-in slack notification on esa.io](https://docs.esa.io/posts/151) ,
display `post.body_md` on the events of post_create and post_update.

Here's the screen shot:

![_10__idobata](https://cloud.githubusercontent.com/assets/2160/10793144/f4c42c92-7dd2-11e5-9283-942e6f04faef.png)

To compare the original version of post_create and post_update, see also #40.

Thanks in advance!