### PR TITLE
esa: Suppress article body from notificaton on post_update

### DIFF
--- a/lib/hooks/esa/templates/post_update.html.haml
+++ b/lib/hooks/esa/templates/post_update.html.haml
@@ -4,5 +4,3 @@
   = link_to_post(payload.team, payload.post, with_diff: true)
 
 %blockquote= payload.post.message
-<br />
-= md payload.post.body_md

--- a/spec/esa_spec.rb
+++ b/spec/esa_spec.rb
@@ -67,8 +67,6 @@ describe Idobata::Hook::Esa, type: :hook do
         <b>たいとる</b>
       </p>
       <blockquote>Update post.</blockquote>
-      <br />
-      <p>ほんぶん</p>
       HTML
     end
 


### PR DESCRIPTION
I found I don't need the full-length article body in the notifications on `post_update` every time.
(a link to diff is enough for me).

So I'd like to suppress this :shower: :shower: :shower:

Thanks in advance!



