### PR TITLE
Use container-based infrastructure for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm: 2.2.3
 cache: [bundler, apt]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ sudo: false
 rvm: 2.2.3
 cache: [bundler, apt]
 
-before_install:
-  - sudo apt-get install libicu-dev
+addons:
+  apt:
+    packages:
+      - libicu-dev
 
 script: bundle exec rake
 


### PR DESCRIPTION
Travis CI recommends to migrate infrastructure.
See more details: http://docs.travis-ci.com/user/migrating-from-legacy/