### PR TITLE
Fix broken change in #54 

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -37,7 +37,7 @@ module Idobata::Hook
 
       headers = ActionDispatch::Http::Headers.new(env)
 
-      payload = hook.new(raw_body, headers).process_payload
+      payload = hook.new(raw_body, headers, params).process_payload
 
       post_to_idobata payload
 


### PR DESCRIPTION
When I send webhook, An error has occurred like this.
I fixed it.
```
$ IDOBATA_HOOK_URL=https://idobata.io/hook/custom/xxxxxxx foreman start
19:03:27 web.1  | started with pid 8423
19:03:28 web.1  | [2015-11-12 19:03:28] INFO  WEBrick 1.3.1
19:03:28 web.1  | [2015-11-12 19:03:28] INFO  ruby 2.2.3 (2015-08-18) [x86_64-darwin14]
19:03:28 web.1  | [2015-11-12 19:03:28] INFO  WEBrick::HTTPServer#start: pid=8423 port=5000
19:03:31 web.1  | ArgumentError - wrong number of arguments (2 for 3):
19:03:31 web.1  | 	/path/to/repos/idobata-hooks/lib/idobata/hook/base.rb:76:in `initialize'
19:03:31 web.1  | 	/path/to/repos/idobata-hooks/app.rb:40:in `new'
19:03:31 web.1  | 	/path/to/repos/idobata-hooks/app.rb:40:in `block in <class:Application>'
```
