### PR TITLE
Add airbrake_error_url

### DIFF
--- a/lib/hooks/airbrake/templates/default.html.haml
+++ b/lib/hooks/airbrake/templates/default.html.haml
@@ -4,6 +4,9 @@
   %span.badge.progress-bar-danger= payload.error.times_occurred
 
 %p
+  %a{href: payload.airbrake_error_url}= payload.airbrake_error_url
+
+%p
   %b= payload.error.error_message
   - if payload.error.last_notice.request_url
     from

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -18,6 +18,9 @@ describe Idobata::Hook::Airbrake, type: :hook do
           <span class='badge progress-bar-danger'>118</span>
         </p>
         <p>
+          <a href='https://airbrake.io/airbrake-error-url'>https://airbrake.io/airbrake-error-url</a>
+        </p>
+        <p>
           <b>RuntimeError: You threw an exception for testing</b>
           from
           <a href='http://airbrake.io:445/pages/exception_test'>http://airbrake.io:445/pages/exception_test</a>
@@ -35,6 +38,9 @@ describe Idobata::Hook::Airbrake, type: :hook do
           <span class='label label-info'>idobata-hooks</span>
           <span class='label label-info'></span>
           <span class='badge progress-bar-danger'>1</span>
+        </p>
+        <p>
+          <a href='https://airbrake.io/airbrake-error-url'>https://airbrake.io/airbrake-error-url</a>
         </p>
         <p>
           <b>NameError: undefined local variable or method `hi' for main:Object</b>

--- a/spec/fixtures/payload/airbrake/rack_error.json
+++ b/spec/fixtures/payload/airbrake/rack_error.json
@@ -32,5 +32,6 @@
     "first_occurred_at":"2012-02-23T22:03:03Z",
     "last_occurred_at":"2012-03-21T08:37:15Z",
     "times_occurred":118
-  }
+  },
+  "airbrake_error_url": "https://airbrake.io/airbrake-error-url"
 }

--- a/spec/fixtures/payload/airbrake/standalone_error.json
+++ b/spec/fixtures/payload/airbrake/standalone_error.json
@@ -36,5 +36,6 @@
     "first_occurred_at": "2014-12-18T05:38:38.53545Z",
     "last_occurred_at": "2014-12-18T05:38:38.53545Z",
     "times_occurred": 1
-  }
+  },
+  "airbrake_error_url": "https://airbrake.io/airbrake-error-url"
 }


### PR DESCRIPTION
Airbrake webhook payload seems to be updated.

https://help.airbrake.io/kb/integrations/webhooks

This patch add airbrake_error_url to body.