### PR TITLE
Update link on GitHub webhook

### DIFF
--- a/app/templates/idobata-hooks/github/help.hbs
+++ b/app/templates/idobata-hooks/github/help.hbs
@@ -1,4 +1,4 @@
 <dl>
 <dt>Usage</dt>
 <dd>You can add webhook URL to your repository.
-<br/>See <a href='https://help.github.com/articles/creating-webhooks' target='_blank'><i class='fa fa-external-link'></i> Creating Webhooks | GitHub Help</a> for more details.</dd></dl>
+<br/>See <a href='https://help.github.com/articles/about-webhooks/' target='_blank'><i class='fa fa-external-link'></i> About Webhooks | GitHub Help</a> for more details.</dd></dl>

--- a/lib/hooks/github/help.html.haml
+++ b/lib/hooks/github/help.html.haml
@@ -3,4 +3,4 @@
   %dd
     You can add webhook URL to your repository.
     %br
-    See <a href='https://help.github.com/articles/creating-webhooks' target='_blank'><i class='fa fa-external-link'></i> Creating Webhooks | GitHub Help</a> for more details.
+    See <a href='https://help.github.com/articles/about-webhooks/' target='_blank'><i class='fa fa-external-link'></i> About Webhooks | GitHub Help</a> for more details.


### PR DESCRIPTION
When you access `https://help.github.com/articles/creating-webhooks`, it is redirected to `https://help.github.com/articles/about-webhooks/`.

So, This patch update link on github's webhook.
