### PR TITLE
Custom hook just ignore unsupported Content-Type

### DIFF
--- a/lib/hooks/custom/hook.rb
+++ b/lib/hooks/custom/hook.rb
@@ -3,6 +3,10 @@ module Idobata::Hook
     screen_name 'Custom Webhook'
     icon_url    gravatar('9fef32520aa08836d774873cb8b7df28')
 
+    rescue_from UnsupportedContentType do
+      skip_processing!
+    end
+
     before_render do
       add_description 'WARNING: "body" is deprecated. Use "source" instead.' if payload.body
     end

--- a/lib/idobata/hook/base.rb
+++ b/lib/idobata/hook/base.rb
@@ -1,4 +1,5 @@
 require 'action_dispatch/http/mime_type'
+require 'active_support/rescuable'
 
 module Idobata::Hook
   class Payload < Hashie::Mash
@@ -8,6 +9,8 @@ module Idobata::Hook
 
   class Base
     include ActiveSupport::Callbacks
+    include ActiveSupport::Rescuable
+
     define_callbacks :render
 
     attr_reader :raw_body, :headers, :params
@@ -143,8 +146,10 @@ module Idobata::Hook
 
         parse_json_in_form(payload)
       else
-        raise Error, "Unsupported content_type: `#{raw_content_type}`."
+        raise UnsupportedContentType, "Unsupported content_type: `#{raw_content_type}`."
       end
+    rescue => e
+      rescue_with_handler(e) || raise
     end
 
     def normalized_content_type

--- a/lib/idobata/hook/errors.rb
+++ b/lib/idobata/hook/errors.rb
@@ -1,10 +1,6 @@
 module Idobata::Hook
-  class Error < StandardError
-  end
-
-  class BadRequest < Error
-  end
-
-  class SkipProcessing < Error
-  end
+  class Error < StandardError; end
+  class BadRequest < Error; end
+  class UnsupportedContentType < Error; end
+  class SkipProcessing < Error; end
 end

--- a/spec/custom_spec.rb
+++ b/spec/custom_spec.rb
@@ -37,10 +37,10 @@ describe Idobata::Hook::Custom, type: :hook do
       its([:source]) { should eq(source) }
       its([:format]) { should eq(:plain) }
 
-      it {
+      it do
         filenames = subject[:images].map {|image| image['filename'] }
         expect(filenames).to eq([image.original_filename])
-      }
+      end
     end
 
     context 'With two image' do
@@ -55,10 +55,10 @@ describe Idobata::Hook::Custom, type: :hook do
       its([:source]) { should eq(source) }
       its([:format]) { should eq(:plain) }
 
-      it {
+      it do
         filenames = subject[:images].map {|image| image['filename'] }
         expect(filenames).to eq([image.original_filename] * 2)
-      }
+      end
     end
 
     context 'urlencoded data without Content-Type' do
@@ -70,6 +70,20 @@ describe Idobata::Hook::Custom, type: :hook do
 
       its([:source]) { should eq(source) }
       its([:format]) { should eq(:plain) }
+    end
+
+    context 'With unsupported Content-Type' do
+      let(:params) { {source: source}.to_query }
+
+      before do
+        post params, 'Content-Type' => 'application/csp-report'
+      end
+
+      it do
+        expect {
+          hook.process_payload
+        }.to raise_error(Idobata::Hook::SkipProcessing)
+      end
     end
   end
 end


### PR DESCRIPTION
If an unknown content type payload arrives in a custom hook, it means a user misconfiguration. We do not need to pay attention to these errors.