### PR TITLE
Show errror message for sentry

### DIFF
--- a/lib/hooks/sentry/templates/default.html.haml
+++ b/lib/hooks/sentry/templates/default.html.haml
@@ -3,3 +3,6 @@
   %a{href: payload.url} ##{payload.id}
   \:
   %span.label{class: label_class_from_level(payload.level)}= payload.level
+
+%p
+  %b= payload.message

--- a/spec/fixtures/payload/sentry/debug.json
+++ b/spec/fixtures/payload/sentry/debug.json
@@ -2,5 +2,6 @@
     "id": "27379932",
     "project_name": "Project Name",
     "level": "debug",
-    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/"
+    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/",
+    "message": "This is an example exception"
 }

--- a/spec/fixtures/payload/sentry/error.json
+++ b/spec/fixtures/payload/sentry/error.json
@@ -2,5 +2,6 @@
     "id": "27379932",
     "project_name": "Project Name",
     "level": "error",
-    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/"
+    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/",
+    "message": "This is an example exception"
 }

--- a/spec/fixtures/payload/sentry/fatal.json
+++ b/spec/fixtures/payload/sentry/fatal.json
@@ -2,5 +2,6 @@
     "id": "27379932",
     "project_name": "Project Name",
     "level": "fatal",
-    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/"
+    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/",
+    "message": "This is an example exception"
 }

--- a/spec/fixtures/payload/sentry/info.json
+++ b/spec/fixtures/payload/sentry/info.json
@@ -2,5 +2,6 @@
     "id": "27379932",
     "project_name": "Project Name",
     "level": "info",
-    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/"
+    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/",
+    "message": "This is an example exception"
 }

--- a/spec/fixtures/payload/sentry/unknown.json
+++ b/spec/fixtures/payload/sentry/unknown.json
@@ -2,5 +2,6 @@
     "id": "27379932",
     "project_name": "Project Name",
     "level": "unknown",
-    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/"
+    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/",
+    "message": "This is an example exception"
 }

--- a/spec/fixtures/payload/sentry/warning.json
+++ b/spec/fixtures/payload/sentry/warning.json
@@ -2,5 +2,6 @@
     "id": "27379932",
     "project_name": "Project Name",
     "level": "warning",
-    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/"
+    "url": "https://app.getsentry.com/getsentry/project-slug/group/27379932/",
+    "message": "This is an example exception"
 }

--- a/spec/sentry_spec.rb
+++ b/spec/sentry_spec.rb
@@ -18,6 +18,9 @@ describe Idobata::Hook::Sentry, type: :hook do
           :
           <span class='label label-danger'>fatal</span>
         </p>
+        <p>
+          <b>This is an example exception</b>
+        </p>
       HTML
 
       its([:format]) { should eq(:html) }
@@ -32,6 +35,9 @@ describe Idobata::Hook::Sentry, type: :hook do
           <a href='https://app.getsentry.com/getsentry/project-slug/group/27379932/'>#27379932</a>
           :
           <span class='label label-danger'>error</span>
+        </p>
+        <p>
+          <b>This is an example exception</b>
         </p>
       HTML
 
@@ -48,6 +54,9 @@ describe Idobata::Hook::Sentry, type: :hook do
           :
           <span class='label label-warning'>warning</span>
         </p>
+        <p>
+          <b>This is an example exception</b>
+        </p>
       HTML
 
       its([:format]) { should eq(:html) }
@@ -62,6 +71,9 @@ describe Idobata::Hook::Sentry, type: :hook do
           <a href='https://app.getsentry.com/getsentry/project-slug/group/27379932/'>#27379932</a>
           :
           <span class='label label-info'>info</span>
+        </p>
+        <p>
+          <b>This is an example exception</b>
         </p>
       HTML
 
@@ -78,6 +90,9 @@ describe Idobata::Hook::Sentry, type: :hook do
           :
           <span class='label label-info'>debug</span>
         </p>
+        <p>
+          <b>This is an example exception</b>
+        </p>
       HTML
 
       its([:format]) { should eq(:html) }
@@ -92,6 +107,9 @@ describe Idobata::Hook::Sentry, type: :hook do
           <a href='https://app.getsentry.com/getsentry/project-slug/group/27379932/'>#27379932</a>
           :
           <span class='label label-default'>unknown</span>
+        </p>
+        <p>
+          <b>This is an example exception</b>
         </p>
       HTML
 


### PR DESCRIPTION
I don't know the error message in idobata. It is inconvenient. 

![2017-08-21 12 52 27](https://user-images.githubusercontent.com/23812/29503055-9fe92d74-866f-11e7-8402-b6546a9a1f4a.png)


![_3__idobata](https://user-images.githubusercontent.com/23812/29503014-4aa3777a-866f-11e7-8043-30a0a1fd49f6.png)

