### PR TITLE
Run `bundle update commonmarker`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,6 @@ cache: [bundler, apt]
 git:
   depth: 1
 
-# CMake 2.8.9 or higher is required
-# https://github.com/gjtorikian/commonmarker/blob/099344c91805000b0253f8aecbb96c38dfa95b9c/.travis.yml
-addons:
-  apt:
-    sources:
-      - kalakris-cmake
-    packages:
-      - cmake
-
 script: bundle exec rake
 
 notifications:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     builder (3.2.3)
     charlock_holmes (0.7.3)
     coderay (1.1.1)
-    commonmarker (0.16.5)
+    commonmarker (0.17.9)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     coveralls (0.8.21)
@@ -74,7 +74,8 @@ GEM
       activesupport
       html-pipeline (>= 1.11)
       rouge (~> 2.0.7)
-    i18n (0.8.4)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -121,7 +122,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    ruby-enum (0.7.1)
+    ruby-enum (0.7.2)
       i18n
     rugged (0.22.2)
     safe_yaml (1.0.4)
@@ -185,4 +186,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.16.1


### PR DESCRIPTION
Updated commonmarker to 0.17.9.

When I tried to deploy this repository on Heroku, I could not deploy because cmake was requested.
This problem is resolved with commonmarker 0.17.9 by the following commit.
https://github.com/gjtorikian/commonmarker/commit/82286340e95d31ad96008a1e2678f74b05630577

### Steps to reproduce

1. `git clone git@github.com:idobata/idobata-hooks.git`
2. `cd idobata-hooks`
3. `heroku create`
4. `heroku git:remote --app appname`
5. `git push heroku`

``` console
[12:51PMnumatanoMacBook-Pro]# git push heroku
Counting objects: 2719, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (1135/1135), done.
Writing objects: 100% (2719/2719), 595.28 KiB | 198.43 MiB/s, done.
Total 2719 (delta 1466), reused 2719 (delta 1466)
remote: Compressing source files... done.
remote: Building source:
remote:
remote:  !     Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
remote: 			Detected buildpacks: Ruby,Node.js
remote: 			See https://devcenter.heroku.com/articles/buildpacks#buildpack-detect-order
remote: -----> Ruby app detected
remote: -----> Compiling Ruby/Rack
remote: -----> Using Ruby version: ruby-2.3.7
remote: -----> Installing dependencies using bundler 1.15.2
remote:        Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
remote:        fatal: Not a git repository (or any parent up to mount point /tmp)
remote:        Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
remote:        Fetching gem metadata from https://rubygems.org/..........
remote:        Fetching version metadata from https://rubygems.org/..
remote:        Fetching dependency metadata from https://rubygems.org/.
remote:        Fetching concurrent-ruby 1.0.5
remote:        Fetching i18n 0.8.4
remote:        Fetching minitest 5.10.2
remote:        Installing i18n 0.8.4
remote:        Installing minitest 5.10.2
remote:        Installing concurrent-ruby 1.0.5
remote:        Fetching thread_safe 0.3.6
remote:        Installing thread_safe 0.3.6
remote:        Fetching builder 3.2.3
remote:        Installing builder 3.2.3
remote:        Fetching erubi 1.6.1
remote:        Installing erubi 1.6.1
remote:        Fetching mini_portile2 2.2.0
remote:        Fetching rack 2.0.3
remote:        Using bundler 1.15.2
remote:        Fetching gemoji 3.0.0
remote:        Installing mini_portile2 2.2.0
remote:        Installing gemoji 3.0.0
remote:        Fetching temple 0.8.0
remote:        Installing temple 0.8.0
remote:        Fetching tilt 2.0.7
remote:        Installing rack 2.0.3
remote:        Installing tilt 2.0.7
remote:        Fetching hashie 3.5.5
remote:        Installing hashie 3.5.5
remote:        Fetching rouge 2.0.7
remote:        Fetching mime-types-data 3.2016.0521
remote:        Installing rouge 2.0.7
remote:        Installing mime-types-data 3.2016.0521
remote:        Fetching sass 3.4.24
remote:        Fetching ruby-enum 0.7.1
remote:        Installing ruby-enum 0.7.1
remote:        Installing sass 3.4.24
remote:        Fetching tzinfo 1.2.3
remote:        Installing tzinfo 1.2.3
remote:        Fetching nokogiri 1.8.0
remote:        Fetching haml 5.0.1
remote:        Installing haml 5.0.1
remote:        Fetching rack-test 0.6.3
remote:        Installing rack-test 0.6.3
remote:        Fetching mime-types 3.1
remote:        Installing mime-types 3.1
remote:        Fetching commonmarker 0.16.5
remote:        Fetching activesupport 5.1.2
remote:        Installing commonmarker 0.16.5 with native extensions
remote:        Installing activesupport 5.1.2
remote:        Installing nokogiri 1.8.0 with native extensions
remote:        Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
remote:
remote:        current directory:
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/gems/commonmarker-0.16.5/ext/commonmarker
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/ruby-2.3.7/bin/ruby -r
remote:        ./siteconf20180420-231-1ligvso.rb extconf.rb
remote:        checking for cmake... no
remote:
remote:
remote:
remote:        [ERROR]: cmake is required and not installed. Get it here: http://www.cmake.org/
remote:
remote:
remote:        *** extconf.rb failed ***
remote:        Could not create Makefile due to some reason, probably lack of necessary
remote:        libraries and/or headers.  Check the mkmf.log file for more details.  You may
remote:        need configuration options.
remote:
remote:        Provided configuration options:
remote:        	--with-opt-dir
remote:        	--without-opt-dir
remote:        	--with-opt-include
remote:        	--without-opt-include=${opt-dir}/include
remote:        	--with-opt-lib
remote:        	--without-opt-lib=${opt-dir}/lib
remote:        	--with-make-prog
remote:        	--without-make-prog
remote:        	--srcdir=.
remote:        	--curdir
remote:        --ruby=/tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/ruby-2.3.7/bin/$(RUBY_BASE_NAME)
remote:
remote:        To see why this extension failed to compile, please check the mkmf.log which can
remote:        be found here:
remote:
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/extensions/x86_64-linux/2.3.0/commonmarker-0.16.5/mkmf.log
remote:
remote:        extconf failed, exit code 1
remote:
remote:        Gem files will remain installed in
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/gems/commonmarker-0.16.5
remote:        for inspection.
remote:        Results logged to
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/extensions/x86_64-linux/2.3.0/commonmarker-0.16.5/gem_make.out
remote:
remote:        An error occurred while installing commonmarker (0.16.5), and Bundler cannot
remote:        continue.
remote:        Make sure that `gem install commonmarker -v '0.16.5'` succeeds before bundling.
remote:
remote:        In Gemfile:
remote:          idobata-hooks was resolved to 2.0.0, which depends on
remote:            commonmarker
remote:        Bundler Output: fatal: Not a git repository (or any parent up to mount point /tmp)
remote:        Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
remote:        Fetching gem metadata from https://rubygems.org/..........
remote:        Fetching version metadata from https://rubygems.org/..
remote:        Fetching dependency metadata from https://rubygems.org/.
remote:        Fetching concurrent-ruby 1.0.5
remote:        Fetching i18n 0.8.4
remote:        Fetching minitest 5.10.2
remote:        Installing i18n 0.8.4
remote:        Installing minitest 5.10.2
remote:        Installing concurrent-ruby 1.0.5
remote:        Fetching thread_safe 0.3.6
remote:        Installing thread_safe 0.3.6
remote:        Fetching builder 3.2.3
remote:        Installing builder 3.2.3
remote:        Fetching erubi 1.6.1
remote:        Installing erubi 1.6.1
remote:        Fetching mini_portile2 2.2.0
remote:        Fetching rack 2.0.3
remote:        Using bundler 1.15.2
remote:        Fetching gemoji 3.0.0
remote:        Installing mini_portile2 2.2.0
remote:        Installing gemoji 3.0.0
remote:        Fetching temple 0.8.0
remote:        Installing temple 0.8.0
remote:        Fetching tilt 2.0.7
remote:        Installing rack 2.0.3
remote:        Installing tilt 2.0.7
remote:        Fetching hashie 3.5.5
remote:        Installing hashie 3.5.5
remote:        Fetching rouge 2.0.7
remote:        Fetching mime-types-data 3.2016.0521
remote:        Installing rouge 2.0.7
remote:        Installing mime-types-data 3.2016.0521
remote:        Fetching sass 3.4.24
remote:        Fetching ruby-enum 0.7.1
remote:        Installing ruby-enum 0.7.1
remote:        Installing sass 3.4.24
remote:        Fetching tzinfo 1.2.3
remote:        Installing tzinfo 1.2.3
remote:        Fetching nokogiri 1.8.0
remote:        Fetching haml 5.0.1
remote:        Installing haml 5.0.1
remote:        Fetching rack-test 0.6.3
remote:        Installing rack-test 0.6.3
remote:        Fetching mime-types 3.1
remote:        Installing mime-types 3.1
remote:        Fetching commonmarker 0.16.5
remote:        Fetching activesupport 5.1.2
remote:        Installing commonmarker 0.16.5 with native extensions
remote:        Installing activesupport 5.1.2
remote:        Installing nokogiri 1.8.0 with native extensions
remote:        Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
remote:
remote:        current directory:
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/gems/commonmarker-0.16.5/ext/commonmarker
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/ruby-2.3.7/bin/ruby -r
remote:        ./siteconf20180420-231-1ligvso.rb extconf.rb
remote:        checking for cmake... no
remote:
remote:
remote:
remote:        [ERROR]: cmake is required and not installed. Get it here: http://www.cmake.org/
remote:
remote:
remote:        *** extconf.rb failed ***
remote:        Could not create Makefile due to some reason, probably lack of necessary
remote:        libraries and/or headers.  Check the mkmf.log file for more details.  You may
remote:        need configuration options.
remote:
remote:        Provided configuration options:
remote:        	--with-opt-dir
remote:        	--without-opt-dir
remote:        	--with-opt-include
remote:        	--without-opt-include=${opt-dir}/include
remote:        	--with-opt-lib
remote:        	--without-opt-lib=${opt-dir}/lib
remote:        	--with-make-prog
remote:        	--without-make-prog
remote:        	--srcdir=.
remote:        	--curdir
remote:        --ruby=/tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/ruby-2.3.7/bin/$(RUBY_BASE_NAME)
remote:
remote:        To see why this extension failed to compile, please check the mkmf.log which can
remote:        be found here:
remote:
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/extensions/x86_64-linux/2.3.0/commonmarker-0.16.5/mkmf.log
remote:
remote:        extconf failed, exit code 1
remote:
remote:        Gem files will remain installed in
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/gems/commonmarker-0.16.5
remote:        for inspection.
remote:        Results logged to
remote:        /tmp/build_41a847bf896d8e1e767429a5c530929e/vendor/bundle/ruby/2.3.0/extensions/x86_64-linux/2.3.0/commonmarker-0.16.5/gem_make.out
remote:
remote:        An error occurred while installing commonmarker (0.16.5), and Bundler cannot
remote:        continue.
remote:        Make sure that `gem install commonmarker -v '0.16.5'` succeeds before bundling.
remote:
remote:        In Gemfile:
remote:          idobata-hooks was resolved to 2.0.0, which depends on
remote:            commonmarker
remote:  !
remote:  !     Failed to install gems via Bundler.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !	Push rejected to morning-spire-49520.
remote:
To https://git.heroku.com/morning-spire-49520.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/morning-spire-49520.git'
```