### PR TITLE
Fix a broken link

### DIFF
--- a/lib/hooks/bugsnag/help.html.haml
+++ b/lib/hooks/bugsnag/help.html.haml
@@ -1,4 +1,4 @@
 %dl
   %dt Usage
   %dd
-    See <a href='https://bugsnag.com/docs/notification-plugins' target='_blank'>Notification Plugins | Webhook</a>.
+    See <a href='https://docs.bugsnag.com/product/integrations/webhook/' target='_blank'>Bugsnag docs › Product › Integrations › Webhook</a>.


### PR DESCRIPTION
Bugsnag docs link seems outdated, but I am not sure that is correct.